### PR TITLE
Use dummy result date if result is inconclusive

### DIFF
--- a/scan/report-en.tex
+++ b/scan/report-en.tex
@@ -69,7 +69,12 @@
 \item [Participant Date of Birth] \textbf{\VAR{birth_date|e}}
 \item [Specimen Identifier] \textbf{\VAR{qrcode|e}}
 \item [Date Sample Submitted] \textbf{\VAR{collect_ts|e}}
-\item [Date Results Provided] \textbf{\VAR{result_ts|e}}
+\item [Date Results Provided]
+  %- if status_code == "never-tested"
+  \textbf{Never tested}
+  %- else
+  \textbf{\VAR{result_ts|e}}
+  %- endif
 \item [Specimen Type] Midnasal, self-collected
 \end{description}
 


### PR DESCRIPTION
The current logic for generating PDFs requires that the `result_ts`
value is defined. Results with a status code of "never-tested" will
never have this field defined. For all "never-tested" status codes, add
a dummy value (to be translated) to the "Date Results Provided" section
of the generated PDF.