### PR TITLE
fill-template: Allow setting logging level from the environment

### DIFF
--- a/fill-template
+++ b/fill-template
@@ -48,6 +48,9 @@ from os.path import basename, dirname
 from sys import stdin, stderr
 
 
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "debug").upper()
+
+
 logging.basicConfig(
     level = logging.ERROR,
     format = "[%(asctime)s] %(levelname)-8s %(message)s",
@@ -57,7 +60,7 @@ logging.basicConfig(
 logging.captureWarnings(True)
 
 log = logging.getLogger(__name__)
-log.setLevel(logging.DEBUG)
+log.setLevel(LOG_LEVEL)
 
 
 # XeLaTeX has the best Unicode support of the various LaTeX engines, which is


### PR DESCRIPTION
I'll use this in our cronjob to reduce noise when it fails (even though we're also using chronic currently).