### PR TITLE
vi: Translate FDA

### DIFF
--- a/scan/report-vi.tex
+++ b/scan/report-vi.tex
@@ -217,11 +217,12 @@ con người. Xét nghiệm này đã được phát triển và Northwest Genom
 thuộc University of Washington đã xác định được các đặc trưng về tính hiệu quả
 của xét nghiệm này. Xét nghiệm này do phòng thí nghiệm phát triển đã được xác
 nhận tính hợp lệ và gửi đến Food and Drug Administration của Hoa Kỳ để xin Giấy
-Phép Sử Dụng Trong Trường Hợp Khẩn Cấp. Đánh giá độc lập của FDA về việc xác
-nhận tính hợp lệ của xét nghiệm vẫn đang chờ phê duyệt. Phòng thí nghiệm này
-được chứng nhận là đủ tiêu chuẩn thực hiện xét nghiệm lâm sàng có độ phức tạp
-cao trong phòng thí nghiệm theo Các Quy Định Sửa Đổi Cải Tiến Phòng Thí Nghiệm
-Lâm Sàng (Clinical Laboratory Improvement Amendments - CLIA).
+Phép Sử Dụng Trong Trường Hợp Khẩn Cấp. Đánh giá độc lập của Cơ Quan Quản Lý
+Dược Phẩm (Food and Drug Administration - FDA) về việc xác nhận tính hợp lệ của
+xét nghiệm vẫn đang chờ phê duyệt. Phòng thí nghiệm này được chứng nhận là đủ
+tiêu chuẩn thực hiện xét nghiệm lâm sàng có độ phức tạp cao trong phòng thí
+nghiệm theo Các Quy Định Sửa Đổi Cải Tiến Phòng Thí Nghiệm Lâm Sàng (Clinical
+Laboratory Improvement Amendments - CLIA).
 
 Để biết thêm thông tin về nhà cung cấp, vui lòng xem các đường dẫn này do
 Washington State Department of Health cung cấp:


### PR DESCRIPTION
A community reviewer caught that we didn't translate the second instance
of "FDA" in the result report. Update the template to translate FDA in
both places.