### PR TITLE
Fix: Use relative path to access fonts in Docker

### DIFF
--- a/scan/report-zh-Hans.tex
+++ b/scan/report-zh-Hans.tex
@@ -29,7 +29,7 @@
   Extension   = .ttf,
   UprightFont = * ]
 \setCJKmainfont{NotoSansCJKsc}[
-  Path        = /output/fonts/,
+  Path        = /src/fonts/,
   Extension   = .otf,
   UprightFont = *-Regular,
   BoldFont    = *-Bold,

--- a/scan/report-zh-Hant.tex
+++ b/scan/report-zh-Hant.tex
@@ -29,7 +29,7 @@
   Extension   = .ttf,
   UprightFont = * ]
 \setCJKmainfont{NotoSansCJKtc}[
-  Path        = /output/fonts/,
+  Path        = /src/fonts/,
   Extension   = .otf,
   UprightFont = *-Regular,
   BoldFont    = *-Bold,


### PR DESCRIPTION
Instead of hard-coding a font Path that's dependent on a specific mount,
copy the font files into the Docker image and refer to them by a
relative path in the templates.