### PR TITLE
Install fontconfig into the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         texlive-xetex \
         texlive-fonts-recommended \
+        fontconfig \
         fonts-noto-cjk \
         wget \
         xzdec


### PR DESCRIPTION
When fontconfig is installed, font information caches (automatically
generated by fc-cache) will be used by XeLaTeX/fontspec.  On my
computer, this reduces generation time for a single PDF from a
mind-boggling ~20s back to a mostly acceptable ~1s.

The latter is how long individual report generation took originally,
before a regression introduced by the installation of fonts-noto-cjk.
I'm guessing that the regression in speed is related to the very
extensive font property tables (character and language sets) of Noto
CJK, which I presume take a while to parse every time without caches.

I used git bisect to find the commit which introduced the regression,
"Translate traditional Chinese SCAN report" (44e3d5e), by rebuilding the
Docker image and timing the generation of a single PDF at every bisect
step.  Notably, I tested using the English report, which meant the
Dockerfile change was the only one which could reasonably explain the
regression.  I also observed that generating the PDF outside of Docker
did not exhibit pathological speeds on any commit.  This hinted at some
difference between the base systems, and it was then that I guessed at
font caches and noticed that fc-cache wasn't installed in the Docker
image.