### PR TITLE
scan-irb: Add methods and limitations section

### DIFF
--- a/scan-irb/report-en.tex
+++ b/scan-irb/report-en.tex
@@ -238,4 +238,40 @@ following:
 
 \end{itemize}
 
+\bigskip
+
+\large \underline{\textbf{Methods and Limitations}}
+
+\textbf{Methods}\\
+This assay is made to detect SARs-CoV-2 using reverse-transcription PCR. This
+assay uses amplification of the virus segments ORf1B and S and also detects a
+human RnaseP amplification control. This test was developed and its performance
+characteristics determined by the University of Washington’s Northwest Genomics
+Center. This laboratory is licensed by the WA Department of Health Medical
+Testing Site as qualified to perform high complexity clinical laboratory
+testing.
+
+\textbf{Limitations}
+
+\begin{itemize}
+
+\item
+
+  These results are provided as part of a research study.
+
+\item
+
+  You collected this sample and labeled it by yourself (or for someone else) and
+  returned it to the lab via a delivery service. It was not collected, labeled,
+  or transported by a healthcare professional like a nurse or doctor. This may
+  impact your test result, and a healthcare provider may want to test you again.
+
+\item
+
+  Because this report is based on data from a research study, your results may
+  not be able to diagnose COVID-19, the disease caused by an infection with
+  SARS-CoV-2.
+
+\end{itemize}
+
 \end{document}


### PR DESCRIPTION
Add a section to the SCAN IRB English template for "Methods and
Limitations" that I accidentally overlooked when creating this template
the first time around .