### PR TITLE
scan-irb: Accept dynamic swab and staff codes

### DIFF
--- a/scan-irb/example-params.csv
+++ b/scan-irb/example-params.csv
@@ -1,7 +1,7 @@
 qrcode,pat_name,birth_date,collect_ts,result_ts,status_code,swab_type,staff_observed
-AAAAAAAA,Not-received Ned,2020-01-01,,,not-received,mtb,true
-BBBBBBBB,Pending Patrick,2020-01-01,2020-06-10,,pending,ans,false
-CCCCCCCC,Never-tested Nellie,2020-01-01,2020-06-10,,never-tested,np,true
-DDDDDDDD,Negative Nancy,2020-01-01,2020-06-10,2020-06-12,negative,mtb,false
-EEEEEEEE,Inconclusive Ian,2020-01-01,2020-06-10,2020-06-12,inconclusive,ans,true
-FFFFFFFF,Positive Pat,2020-01-01,2020-06-10,2020-06-12,positive,np,false
+AAAAAAAA,Not-received Ned,2020-01-01,,,not-received,mtb,t
+BBBBBBBB,Pending Patrick,2020-01-01,2020-06-10,,pending,ans,f
+CCCCCCCC,Never-tested Nellie,2020-01-01,2020-06-10,,never-tested,np,t
+DDDDDDDD,Negative Nancy,2020-01-01,2020-06-10,2020-06-12,negative,mtb,f
+EEEEEEEE,Inconclusive Ian,2020-01-01,2020-06-10,2020-06-12,inconclusive,ans,t
+FFFFFFFF,Positive Pat,2020-01-01,2020-06-10,2020-06-12,positive,np,f

--- a/scan-irb/example-params.csv
+++ b/scan-irb/example-params.csv
@@ -1,7 +1,7 @@
 qrcode,pat_name,birth_date,collect_ts,result_ts,status_code,swab_type,staff_observed
 AAAAAAAA,Not-received Ned,2020-01-01,,,not-received,mtb,t
 BBBBBBBB,Pending Patrick,2020-01-01,2020-06-10,,pending,ans,f
-CCCCCCCC,Never-tested Nellie,2020-01-01,2020-06-10,,never-tested,np,t
+CCCCCCCC,Never-tested Nellie,2020-01-01,2020-06-10,,never-tested,ans,t
 DDDDDDDD,Negative Nancy,2020-01-01,2020-06-10,2020-06-12,negative,mtb,f
-EEEEEEEE,Inconclusive Ian,2020-01-01,2020-06-10,2020-06-12,inconclusive,ans,t
-FFFFFFFF,Positive Pat,2020-01-01,2020-06-10,2020-06-12,positive,np,f
+EEEEEEEE,Inconclusive Ian,2020-01-01,2020-06-10,2020-06-12,inconclusive,mtb,t
+FFFFFFFF,Positive Pat,2020-01-01,2020-06-10,2020-06-12,positive,ans,f

--- a/scan-irb/example-params.csv
+++ b/scan-irb/example-params.csv
@@ -1,7 +1,7 @@
-qrcode,pat_name,birth_date,collect_ts,result_ts,status_code
-AAAAAAAA,Not-received Ned,2020-01-01,,,not-received
-BBBBBBBB,Pending Patrick,2020-01-01,2020-06-10,,pending
-CCCCCCCC,Never-tested Nellie,2020-01-01,2020-06-10,,never-tested
-DDDDDDDD,Negative Nancy,2020-01-01,2020-06-10,2020-06-12,negative
-EEEEEEEE,Inconclusive Ian,2020-01-01,2020-06-10,2020-06-12,inconclusive
-FFFFFFFF,Positive Pat,2020-01-01,2020-06-10,2020-06-12,positive
+qrcode,pat_name,birth_date,collect_ts,result_ts,status_code,swab_type,staff_observed
+AAAAAAAA,Not-received Ned,2020-01-01,,,not-received,mtb,true
+BBBBBBBB,Pending Patrick,2020-01-01,2020-06-10,,pending,ans,false
+CCCCCCCC,Never-tested Nellie,2020-01-01,2020-06-10,,never-tested,np,true
+DDDDDDDD,Negative Nancy,2020-01-01,2020-06-10,2020-06-12,negative,mtb,false
+EEEEEEEE,Inconclusive Ian,2020-01-01,2020-06-10,2020-06-12,inconclusive,ans,true
+FFFFFFFF,Positive Pat,2020-01-01,2020-06-10,2020-06-12,positive,np,false

--- a/scan-irb/report-en.tex
+++ b/scan-irb/report-en.tex
@@ -118,12 +118,12 @@ Before looking at your research test result, you should review the following:
   \textbf{research test result.}
 
 \item
-%- if staff_observed == "false"
+%- if staff_observed == "f"
   You collected this sample and labeled it by yourself (or for someone else) and
   returned it to the lab via a delivery service. It was not collected, labeled,
   or transported by a licensed healthcare professional like a nurse or doctor.
 
-  %- elif staff_observed == "true"
+  %- elif staff_observed == "t"
   You collected this sample by yourself (or for someone else) and it was labeled
   and returned to the lab via a courier or other type of non-healthcare
   professional. It was not collected or transported by a licensed healthcare
@@ -284,12 +284,12 @@ testing.
   These results are provided as part of a research study.
 
 \item
-  %- if staff_observed == "false"
+  %- if staff_observed == "f"
   You collected this sample and labeled it by yourself (or for someone else) and
   returned it to the lab via a delivery service. It was not collected, labeled,
   or transported by a healthcare professional like a nurse or doctor.
 
-  %- elif staff_observed == "true"
+  %- elif staff_observed == "t"
   You collected this sample by yourself (or for someone else) and it was labeled
   and returned to the lab via a courier or other type of non-healthcare
   professional. It was not collected or transported by a licensed healthcare

--- a/scan-irb/report-en.tex
+++ b/scan-irb/report-en.tex
@@ -63,8 +63,6 @@
   Anterior Nasal,
   %- elif swab_type == "mtb"
   Midnasal,
-  %- elif swab_type == "np"
-  Nasopharyngeal,
   %- else
   \errmessage{Invalid swab_type "\VAR{swab_type}"}
   %- endif

--- a/scan-irb/report-en.tex
+++ b/scan-irb/report-en.tex
@@ -58,7 +58,19 @@
 \begin{description}[font=\normalfont,align=left,labelwidth=12em]
 \item [\textbf{\VAR{pat_name|e}}]
 \item [\textbf{Date of Birth}] \VAR{birth_date|e}
-\item [\textbf{Specimen}] Midnasal, self-collected
+\item [\textbf{Specimen}]
+  %- if swab_type == "ans"
+  Anterior Nasal,
+  %- elif swab_type == "mtb"
+  Midnasal,
+  %- elif swab_type == "np"
+  Nasopharyngeal,
+  %- else
+  \errmessage{Invalid swab_type "\VAR{swab_type}"}
+  %- endif
+
+  self-collected
+
 \item [\textbf{Collection Barcode}] \VAR{qrcode|e}
 \item [\textbf{Collection Date}] \VAR{collect_ts|e}
 \item [\textbf{Report Date}]
@@ -106,10 +118,19 @@ Before looking at your research test result, you should review the following:
   \textbf{research test result.}
 
 \item
-
+%- if staff_observed == "false"
   You collected this sample and labeled it by yourself (or for someone else) and
   returned it to the lab via a delivery service. It was not collected, labeled,
   or transported by a licensed healthcare professional like a nurse or doctor.
+
+  %- elif staff_observed == "true"
+  You collected this sample by yourself (or for someone else) and it was labeled
+  and returned to the lab via a courier or other type of non-healthcare
+  professional. It was not collected or transported by a licensed healthcare
+  professional like a nurse or doctor.
+
+  %- endif
+
   This may impact your test result, and a healthcare provider may want to test
   you again.
 
@@ -260,11 +281,21 @@ testing.
   These results are provided as part of a research study.
 
 \item
-
+  %- if staff_observed == "false"
   You collected this sample and labeled it by yourself (or for someone else) and
   returned it to the lab via a delivery service. It was not collected, labeled,
-  or transported by a healthcare professional like a nurse or doctor. This may
-  impact your test result, and a healthcare provider may want to test you again.
+  or transported by a healthcare professional like a nurse or doctor.
+
+  %- elif staff_observed == "true"
+  You collected this sample by yourself (or for someone else) and it was labeled
+  and returned to the lab via a courier or other type of non-healthcare
+  professional. It was not collected or transported by a licensed healthcare
+  professional like a nurse or doctor.
+
+  %- endif
+
+  This may impact your test result, and a healthcare provider may want to test
+  you again.
 
 \item
 

--- a/scan-irb/report-en.tex
+++ b/scan-irb/report-en.tex
@@ -129,6 +129,9 @@ Before looking at your research test result, you should review the following:
   professional. It was not collected or transported by a licensed healthcare
   professional like a nurse or doctor.
 
+  %- else
+  \errmessage{Unknown value: staff_observed = "\VAR{staff_observed}"}
+
   %- endif
 
   This may impact your test result, and a healthcare provider may want to test
@@ -291,6 +294,9 @@ testing.
   and returned to the lab via a courier or other type of non-healthcare
   professional. It was not collected or transported by a licensed healthcare
   professional like a nurse or doctor.
+
+  %- else
+  \errmessage{Unknown value: staff_observed = "\VAR{staff_observed}"}
 
   %- endif
 

--- a/scan-irb/report-es.tex
+++ b/scan-irb/report-es.tex
@@ -63,7 +63,7 @@
   %- if swab_type == "ans"
   Hisopo nasal anterior,
   %- elif swab_type == "mtb"
-  Hisopado nasal del cornete medio,
+  Hisopo nasal del cornete medio,
   %- else
   \errmessage{Invalid swab_type "\VAR{swab_type}"}
   %- endif

--- a/scan-irb/report-es.tex
+++ b/scan-irb/report-es.tex
@@ -59,7 +59,17 @@
 \begin{description}[font=\normalfont,align=left,labelwidth=18em]
 \item [\textbf{\VAR{pat_name|e}}]
 \item [\textbf{Fecha de nacimiento}] \VAR{birth_date|e}
-\item [\textbf{Muestra}] hisopado nasal del cornete medio, extraída por el paciente
+\item [\textbf{Muestra}]
+  %- if swab_type == "ans"
+  Hisopo nasal anterior,
+  %- elif swab_type == "mtb"
+  Hisopado nasal del cornete medio,
+  %- else
+  \errmessage{Invalid swab_type "\VAR{swab_type}"}
+  %- endif
+
+  extraída por el paciente
+
 \item [\textbf{Código de barras de la extracción}] \VAR{qrcode|e}
 \item [\textbf{Fecha de la extracción}] \VAR{collect_ts|e}
 \item [\textbf{Fecha del informe}]
@@ -108,12 +118,26 @@ lo siguiente:
   informe describe el resultado de la \textbf{prueba de investigación}.
 
 \item
-
+  %- if staff_observed == "f"
   Extrajo esta muestra y la etiquetó usted mismo (o para otra persona) y la
   devolvió al laboratorio mediante un servicio de entrega. No la extrajo,
   etiquetó o transportó un profesional de la salud con licencia, como un
-  enfermero o médico. Esto podrá afectar el resultado de la prueba, y es posible
-  que un proveedor de atención médica desee volver a realizarla.
+  enfermero o médico.
+
+  %- elif staff_observed == "t"
+  Usted recogió esta muestra por su cuenta (o para otra persona) y fue etiquetada
+  y devuelta al laboratorio a través de un servicio de mensajería o de otro
+  tipo de profesional que no se dedica a la atención médica.  No la extrajo o
+  transportó un profesional de la salud con licencia, como un enfermero o
+  médico.
+
+  %- else
+  \errmessage{Unknown value: staff_observed = "\VAR{staff_observed}"}
+
+  %- endif
+
+  Esto podrá afectar el resultado de la prueba, y es posible que un proveedor de
+  atención médica desee volver a realizarla.
 
 \item
 
@@ -276,9 +300,23 @@ realizar pruebas de laboratorio clínico de alta complejidad.
 
 \item
 
+  %- if staff_observed == "f"
   Extrajo esta muestra y la etiquetó usted mismo (o para otra persona) y la
   devolvió al laboratorio mediante un servicio de entrega. No la extrajo,
   etiquetó o transportó un profesional de la salud, como un enfermero o médico.
+
+  %- elif staff_observed == "t"
+  Usted recogió esta muestra por su cuenta (o para otra persona) y fue etiquetada
+  y devuelta al laboratorio a través de un servicio de mensajería o de otro
+  tipo de profesional que no se dedica a la atención médica.  No la extrajo o
+  transportó un profesional de la salud con licencia, como un enfermero o
+  médico.
+
+  %- else
+  \errmessage{Unknown value: staff_observed = "\VAR{staff_observed}"}
+
+  %- endif
+
   Esto podrá afectar el resultado de la prueba, y es posible que un proveedor de
   atención médica desee volver a realizarla.
 

--- a/scan-irb/report-zh-Hant.tex
+++ b/scan-irb/report-zh-Hant.tex
@@ -65,7 +65,17 @@
 \begin{description}[font=\normalfont,align=left,labelwidth=6em]
 \item [\textbf{\VAR{pat_name|e}}]
 \item [\textbf{出生日期：}] \VAR{birth_date|e}
-\item [\textbf{標本：}] 鼻腔中部，自我採集
+\item [\textbf{標本：}]
+  %- if swab_type == "ans"
+  鼻腔拭子,
+  %- elif swab_type == "mtb"
+  鼻腔中部，
+  %- else
+  \errmessage{Invalid swab_type "\VAR{swab_type}"
+  %- endif
+
+  自我採集
+
 \item [\textbf{採集條碼：}] \VAR{qrcode|e}
 \item [\textbf{採集日期：}] \VAR{collect_ts|e}
 \item [\textbf{報告日期：}]
@@ -109,10 +119,20 @@
   本報告介紹了您的\textbf{研究檢測結果。}
 
 \item
-
+  %- if staff_observed == "f"
   您自己（或為他人）採集樣本並貼上標籤後，透過快遞將其送回實驗室。
-  它不是由護士或醫生等有執照的醫療保健專業人員採集、貼標籤或運送的。這可能會影響您的檢測結果，
-  醫療保健提供者可能希望再次對您進行檢測。
+  它不是由護士或醫生等有執照的醫療保健專業人員採集、貼標籤或運送的
+
+  %- elif staff_observed == "t"
+  您自行（或為他人）採集樣本，由快遞員或其他類型的非醫療保健專業人員貼上標籤並將其送回實驗室。
+  它不是由護士或醫生等有執照的醫療保健專業人員採集或運送的。
+
+  %- else
+  \errmessage{Unknown value: staff_observed = "\VAR{staff_observed}"}
+
+  %- endif
+
+  這可能會影響您的檢測結果，醫療保健提供者可能希望再次對您進行檢測。
 
 \item
 
@@ -247,10 +267,19 @@ RnaseP 擴增對照。該檢測由 University of Washington 的 Northwest Genomi
   這些結果只是研究的一部分內容。
 
 \item
-
+  %- if staff_observed == "f"
   您自己（或為他人）採集樣本並貼上標籤後，透過快遞將其送回實驗室。
-  它不是由護士或醫生等醫療保健專業人員採集、貼標籤或運送的。這可能會影響您的檢測結果，
-  醫療保健提供者可能希望再次對您進行檢測。
+  它不是由護士或醫生等醫療保健專業人員採集、貼標籤或運送的。
+
+  %- elif staff_observed == "t"
+  您自行（或為他人）採集樣本，由快遞員或其他類型的非醫療保健專業人員貼上標籤並將其送回實驗室。
+  它不是由護士或醫生等有執照的醫療保健專業人員採集或運送的。
+
+  %- else
+  \errmessage{Unknown value: staff_observed = "\VAR{staff_observed}"}
+
+  %- endif
+  這可能會影響您的檢測結果，醫療保健提供者可能希望再次對您進行檢測。
 
 \item
 


### PR DESCRIPTION
We now have SCAN IRB studies that have multiple swab types and multiple
~collection methods (self-collected or staff-collected)~ observation methods. Replace the
hard-coded values in the current, English template to account for this.

This depends on concurrent changes in the backoffice RoR workflow. ~For example, we need to converge on what these swab type and collection method columns will be called and what set of values they'll contain.~

We will also need translations for the new swab type and the "staff collected" collection method, so part of this PR is also to vet the language I used in these templates. 

