### PR TITLE
Install the TexLive droid font from a debian package instead of tlmgr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,12 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         texlive-xetex \
         texlive-fonts-recommended \
+        texlive-fonts-extra \
         fontconfig \
         fonts-noto-cjk \
         wget \
         xzdec
 
-RUN tlmgr init-usertree --usertree $(kpsewhich -var-value TEXMFLOCAL)
-RUN tlmgr install --usertree $(kpsewhich -var-value TEXMFLOCAL) droid
 
 WORKDIR /src
 


### PR DESCRIPTION
Use the Debian package texlive-fonts-extra instead of the installing the
droid package using the tlmgr package manager.
This increases our docker image size because it includes other fonts,
but during image build, tlmgr was no longer able to download the texlive
database even after trying multiple different mirrors. This takes that
out of the equation.